### PR TITLE
Remove --check-motorway-link from US-MA-MBTA

### DIFF
--- a/UTC-05/US/MA/US-MA-MBTA/settings.sh
+++ b/UTC-05/US/MA/US-MA-MBTA/settings.sh
@@ -16,7 +16,7 @@ ANALYSIS_PAGE="MBTA/Analysis"
 ANALYSIS_TALK="Talk:MBTA/Analysis"
 WIKI_ROUTES_PAGE="MBTA/Analysis/MBTA-Routes"
 
-ANALYSIS_OPTIONS="--check-gtfs --link-gtfs --show-gtfs --gtfs-feed=$PREFIX --allow-coach --check-access --check-way-type --check-service-type --check-name-relaxed --check-stop-position --check-sequence --check-version --check-osm-separator --check-motorway-link --max-error=20 --multiple-ref-type-entries=analyze --positive-notes --coloured-sketchline --check-bus-stop --check-roundabouts --expect-network-short"
+ANALYSIS_OPTIONS="--check-gtfs --link-gtfs --show-gtfs --gtfs-feed=$PREFIX --allow-coach --check-access --check-way-type --check-service-type --check-name-relaxed --check-stop-position --check-sequence --check-version --check-osm-separator --max-error=20 --multiple-ref-type-entries=analyze --positive-notes --coloured-sketchline --check-bus-stop --check-roundabouts --expect-network-short"
 
 # --check-platform
 # --expect-network-long


### PR DESCRIPTION
In the US, motorway_link is tagged on roads that can be used without going on to the motorway, so this check has too many false positives.

See https://wiki.openstreetmap.org/wiki/Tag:highway%3Dmotorway_link#Link_roads_between_different_highways_types